### PR TITLE
Add figsize parameter to get_patterns() for customizable plot sizes

### DIFF
--- a/build/lib/pyampute/exploration/md_patterns.py
+++ b/build/lib/pyampute/exploration/md_patterns.py
@@ -1,4 +1,5 @@
 """Displays missing data patterns in incomplete datasets"""
+
 # Author: Rianne Schouten <https://rianneschouten.github.io/>
 # Co-Author: Srinidhi Ilango
 
@@ -61,7 +62,11 @@ class mdPatterns:
         self.md_patterns = None
 
     def get_patterns(
-        self, X: Matrix, count_or_proportion: str = "count", show_plot: bool = True
+        self,
+        X: Matrix,
+        count_or_proportion: str = "count",
+        show_plot: bool = True,
+        figsize: tuple = (10, 8),
     ) -> pd.DataFrame:
         """Extracts and visualizes missing data patterns in an incomplete dataset
 
@@ -69,19 +74,19 @@ class mdPatterns:
         ----------
         X : Matrix of shape `(n, m)`
             Dataset with missing values. `n` rows (samples) and `m` columns (features).
-        
+
         count_or_proportion : str, {"count", "proportion"}, default : "count"
-            Whether the number of rows should be specified as a count or a proportion. 
+            Whether the number of rows should be specified as a count or a proportion.
 
         show_plot : bool, default : True
-            Whether a plot should be displayed using ``plt.show``. 
+            Whether a plot should be displayed using ``plt.show``.
 
         Returns
         -------
         md_patterns : pandas DataFrame of shape `(k+2, m+2)`
-            `k` is the number of unique missing data patterns and `m` the number of dataset columns (features). 
-            The first row displays the data rows with no missing values and the last row gives column totals. 
-            The first column displays the count or proportion of rows that follow a pattern, 
+            `k` is the number of unique missing data patterns and `m` the number of dataset columns (features).
+            The first row displays the data rows with no missing values and the last row gives column totals.
+            The first column displays the count or proportion of rows that follow a pattern,
             the last column displays the number of missing values per pattern.
         """
 
@@ -93,7 +98,7 @@ class mdPatterns:
 
         # make plot
         if show_plot:
-            self._make_plot()
+            self._make_plot(figsize=figsize)
 
         return self.md_patterns
 
@@ -149,8 +154,8 @@ class mdPatterns:
         )
         return self.md_patterns
 
-    def _make_plot(self):
-        """"Creates visualization of missing data patterns"""
+    def _make_plot(self, figsize: tuple = (10, 8)):
+        """ "Creates visualization of missing data patterns"""
 
         group_values = self.md_patterns
 
@@ -162,7 +167,7 @@ class mdPatterns:
         myblue = "#006CC2B3"
         cmap = colors.ListedColormap([myred, myblue])
 
-        fig, ax = plt.subplots(1)
+        fig, ax = plt.subplots(figsize=figsize)
         ax.imshow(heat_values.astype(bool), aspect="auto", cmap=cmap)
 
         by = ax.twinx()  # right ax


### PR DESCRIPTION
**Changes Summary**

1. Added `figsize` Parameter in `get_patterns()` Method:
    
    - Introduced a new parameter `figsize` to the `get_patterns()` method, which allows the user to specify the size of the figure when plotting the missing data patterns.
    - Default value is set to `(10, 8)`, which can be overridden by the user.
    - Passed the `figsize` parameter to the `_make_plot()` method.

```python
def get_patterns(
    self, 
    X: Matrix, 
    count_or_proportion: str = "count", 
    show_plot: bool = True, 
    figsize: tuple = (10, 8)  # Added figsize as an optional parameter
) -> pd.DataFrame:
    # Other code remains the same
    
    # Pass the figsize to the _make_plot method
    if show_plot:
        self._make_plot(figsize=figsize)

    return self.md_patterns
```

2. Modified `_make_plot()` Method to Accept `figsize`:

    - Updated the `_make_plot()` method to accept the `figsize` parameter.
    - This `figsize` is used when creating the `plt.subplots` to determine the size of the plot.

```python
def _make_plot(self, figsize: tuple = (10, 8)):
    """"Creates visualization of missing data patterns"""
    
    # Other code remains the same
    
    fig, ax = plt.subplots(figsize=figsize)  # Use the figsize passed as an argument
    
    # Remaining code for plotting
    plt.show()
```

**How It Works Now**

- When you call `get_patterns()` on an instance of `mdPatterns`, you can pass the `figsize` parameter to specify the size of the plot.

- The `figsize` is then used in the `_make_plot()` method to create the plot with the desired dimensions.

**New Implementation**

```python
mdp = mdPatterns()
patterns = mdp.get_patterns(X=your_data, figsize=(12, 10))  # Custom figure size
```

This change provides flexibility to the end user, allowing them to adjust the size of the plot, which helps in preventing issues like scrunched-up labels when dealing with datasets that have many columns or rows.